### PR TITLE
SimSettings: Disable entry for missing sim

### DIFF
--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -130,6 +130,9 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         for (int i = 0; i < mNumSlots; ++i) {
             final SubscriptionInfo sir = mSubscriptionManager
                     .getActiveSubscriptionInfoForSimSlotIndex(i);
+            final int subscriptionId = sir != null ?
+                    sir.getSubscriptionId() :
+                    SubscriptionManager.INVALID_SUBSCRIPTION_ID;
             SimPreference simPreference = new SimPreference(getPrefContext(), sir, i);
             simPreference.setOrder(i-mNumSlots);
             mSimCards.addPreference(simPreference);
@@ -141,12 +144,13 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
             Intent mobileNetworkIntent = new Intent();
             mobileNetworkIntent.setComponent(new ComponentName(
                         "com.android.phone", "com.android.phone.MobileNetworkSettings"));
-            SubscriptionManager.putPhoneIdAndSubIdExtra(mobileNetworkIntent,
-                    i, sir != null ? sir.getSubscriptionId() : -1);
+            SubscriptionManager.putPhoneIdAndSubIdExtra(mobileNetworkIntent, i, subscriptionId);
             Preference mobileNetworkPref = new Preference(getActivity());
             mobileNetworkPref.setTitle(
                     getString(R.string.sim_mobile_network_settings_title, (i + 1)));
             mobileNetworkPref.setIntent(mobileNetworkIntent);
+            mobileNetworkPref.setEnabled(
+                    subscriptionId != SubscriptionManager.INVALID_SUBSCRIPTION_ID);
             mMobileNetwork.addPreference(mobileNetworkPref);
         }
         updateAllOptions();


### PR DESCRIPTION
Clicking on a missing SIM card will show incorrect information
because the user network preference is indexed by subscription id.

This means that when the SIM is not present we cannot infer which
subscription settings we are actually showing or changing so the
whole screen is effectively useless.

This patch disables configuration entries for invalid subscriptions.

Ticket: CYNGNOS-1794
Change-Id: Ic5125f66f4cdaafe06d03b3b20b80341525d6c87