### PR TITLE
Expose option to change the device hostname.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -347,6 +347,9 @@
     <string name="adb_over_network_summary">Enable TCP/IP debugging over network interfaces (Wi\u2011Fi, USB networks). This setting is reset on reboot</string>
     <string name="adb_over_network_warning">WARNING: When ADB over network is enabled, your phone is open for intrusions on all connected networks!\n\nOnly use this feature when you are connected on trusted networks.\n\nDo you really want to enable this function?</string>
 
+    <!-- Hostname setting -->
+    <string name="device_hostname">Device hostname</string>
+
     <!-- Increasing ring tone volume -->
     <string name="increasing_ring_volume_option_title">Increasing ring volume</string>
     <string name="increasing_ring_min_volume_title">Start volume</string>

--- a/res/xml/development_prefs.xml
+++ b/res/xml/development_prefs.xml
@@ -151,6 +151,17 @@
         <Preference android:key="clear_adb_keys"
                 android:title="@string/clear_adb_keys" />
 
+        <com.android.settings.HostnamePreference
+            android:key="device_hostname"
+            android:title="@string/device_hostname"
+            android:dialogTitle="@string/device_hostname"
+            android:positiveButtonText="@string/wifi_save"
+            android:negativeButtonText="@string/wifi_cancel"
+            android:selectAllOnFocus="true"
+            android:imeOptions="actionDone"
+            android:inputType="textNoSuggestions"
+            android:persistent="false" />
+
         <SwitchPreference
             android:key="enable_terminal"
             android:title="@string/enable_terminal_title"

--- a/src/com/android/settings/HostnamePreference.java
+++ b/src/com/android/settings/HostnamePreference.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2013 The CyanogenMod project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+import android.support.v7.preference.EditTextPreference;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import cyanogenmod.providers.CMSettings;
+
+public class HostnamePreference extends EditTextPreference {
+
+    private static final String TAG = "HostnamePreference";
+
+    private static final String PROP_HOSTNAME = "net.hostname";
+
+    public HostnamePreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        setSummary(getText());
+    }
+
+    public HostnamePreference(Context context, AttributeSet attrs) {
+        this(context, attrs, com.android.internal.R.attr.editTextPreferenceStyle);
+    }
+
+    public HostnamePreference(Context context) {
+        this(context, null);
+    }
+
+    @Override
+    public void setText(String text) {
+        if (text == null) {
+            Log.e(TAG, "tried to set null hostname, request ignored");
+            return;
+        }
+        // remove any character that is not alphanumeric, period, or hyphen
+        text = text.replaceAll("[^-.a-zA-Z0-9]", "");
+        if (text.length() == 0) {
+            Log.w(TAG, "setting empty hostname");
+        } else {
+            Log.i(TAG, "hostname has been set: " + text);
+        }
+        SystemProperties.set(PROP_HOSTNAME, text);
+        persistHostname(text);
+        setSummary(text);
+    }
+
+    @Override
+    public String getText() {
+        return SystemProperties.get(PROP_HOSTNAME);
+    }
+
+    @Override
+    public void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        persistHostname(getText());
+    }
+
+    public void persistHostname(String hostname) {
+        CMSettings.Secure.putString(getContext().getContentResolver(),
+                CMSettings.Secure.DEVICE_HOSTNAME, hostname);
+    }
+}


### PR DESCRIPTION
This adds an option to modify the device hostname used
in ip resolution. This is useful when connecting to the
android device in a dynamic dhcp environment.

Change-Id: I1d8302f06144dbb3e6ddba68594cc5718b4f0bb7
(based on commit Ibc145b74036617248d4f33c6866cc9c8a8cc8974)